### PR TITLE
Allows the edit of HTTP Only cookies.

### DIFF
--- a/source/common/javascript/generated/view-cookie-information.js
+++ b/source/common/javascript/generated/view-cookie-information.js
@@ -236,9 +236,11 @@ WebDeveloper.Generated.generateCommands = function(cookie, locale)
   // If the cookie is HTTP only
   if(cookie.httpOnly)
   {
-    element.setAttribute("class", "web-developer-edit btn");
-    element.setAttribute("data-content", locale.cannotEditHTTPOnlyCookies);
-    element.setAttribute("data-title", locale.cannotEdit);
+  	//Added to allow the edit of HTTP Only cookies.
+    element.setAttribute("class", "web-developer-edit btn btn-primary");
+    //element.setAttribute("class", "web-developer-edit btn");
+    //element.setAttribute("data-content", locale.cannotEditHTTPOnlyCookies);
+    //element.setAttribute("data-title", locale.cannotEdit);
   }
   else if(!WebDeveloper.Cookies.canEditLocalCookie() && (cookieHost == "localhost" || cookieHost == ".localhost"))
   {


### PR DESCRIPTION
This worked in previous versions and is a helpful feature to edit
cookies with the HTTP Only flag.

Please consider re-enabling this feature.
