### PR TITLE
Responsive layouts and iframe killer

### DIFF
--- a/source/common/javascript/generated/view-responsive-layouts.js
+++ b/source/common/javascript/generated/view-responsive-layouts.js
@@ -73,7 +73,7 @@ WebDeveloper.Generated.initialize = function(data, locale)
     childElement.setAttribute("scrolling", "yes");
     childElement.setAttribute("src", url);
     childElement.setAttribute("width", parseInt(width, 10) + scrollbarWidth);
-    childElement.setAttribute("sandbox", "allow-forms allow-scripts");
+    childElement.setAttribute("sandbox", "allow-forms allow-scripts allow-same-origin");
 
     container.appendChild(childElement);
     content.appendChild(container);


### PR DESCRIPTION
http://forums.chrispederick.com/discussion/271/iframe-killer-and-responsive-layouts

Responsive layouts is not useful for page with iframe killer, ex. http://www.wp.pl/ We usually use it for security reason ex. on profile pages.

I add this code:
   sandbox="allow-forms allow-scripts"
to iframe tag, page looks good and works correctly on Chrome (FF don't support this solution yet: https://bugzilla.mozilla.org/show_bug.cgi?id=785310 ) in responsive layout.
