### PR TITLE
Chrome: Set window state when resizing

### DIFF
--- a/source/chrome/javascript/overlay/resize.js
+++ b/source/chrome/javascript/overlay/resize.js
@@ -121,6 +121,9 @@ WebDeveloper.Overlay.Resize.resizeWindow = function(height, width)
     {
       size.width = parseInt(width, 10);
     }
+    
+    // Set window state to normal when resizing window
+    size.state = 'normal';
 
     chrome.windows.update(selectedWindow.id, size, function()
     {


### PR DESCRIPTION
Resize does not work when resizing from maximized window. In that case window state must be set to 'normal'
