### PR TITLE
fixed ff-console null errors w/ if(!null) wrappers

### DIFF
--- a/source/firefox/javascript/overlay/overlay.js
+++ b/source/firefox/javascript/overlay/overlay.js
@@ -537,14 +537,18 @@ WebDeveloper.Overlay.setupViewSourceWithKeyboardShortcuts = function(keySet)
 // Handles a tab being selected
 WebDeveloper.Overlay.tabSelect = function()
 {
-  // If a feature that uses the element information toolbar is active
-  if(WebDeveloper.Dashboard.isOpenInDashboard(WebDeveloper.Locales.getString("elementInformation")) || WebDeveloper.Dashboard.isOpenInDashboard(WebDeveloper.Locales.getString("styleInformation")))
-  {
-    document.getElementById("web-developer-element-information-toolbar").hidden = false;
-  }
-  else
-  {
-    document.getElementById("web-developer-element-information-toolbar").hidden = true;
+  var el = document.getElementById("web-developer-element-information-toolbar");
+
+  if (el) {
+    // If a feature that uses the element information toolbar is active
+    if(WebDeveloper.Dashboard.isOpenInDashboard(WebDeveloper.Locales.getString("elementInformation")) || WebDeveloper.Dashboard.isOpenInDashboard(WebDeveloper.Locales.getString("styleInformation")))
+    {
+      el.hidden = false;
+    }
+    else
+    {
+      el.hidden = true;
+    }
   }
 
   WebDeveloper.Overlay.resetCSSStatus();
@@ -826,7 +830,9 @@ WebDeveloper.Overlay.updateJavaScriptStatus = function(error)
 // Updates meta redirects
 WebDeveloper.Overlay.updateMetaRedirects = function(browserElement)
 {
-  browserElement.docShell.allowMetaRedirects = !WebDeveloper.Preferences.getExtensionBooleanPreference("meta.redirects.disable");
+  if (browserElement) {
+    browserElement.docShell.allowMetaRedirects = !WebDeveloper.Preferences.getExtensionBooleanPreference("meta.redirects.disable");
+  }
 };
 
 // Updates the render mode status button


### PR DESCRIPTION
I added a couple if() wrappers around lines that have been showing up as errors in the firefox browser-console. I'm not sure why these were happening in the first place, but the workaround is simple and only touches lines that were failing anyway. Maybe somebody more familiar with the source can check if the error this is hiding is actually relevant.

This is a workaround for this issue mentioned in the forums:
    http://forums.chrispederick.com/discussion/386/document-getelementbyid-is-null-7333
