### PR TITLE
800px width issues

### DIFF
--- a/source/chrome/javascript/overlay/overlay.js
+++ b/source/chrome/javascript/overlay/overlay.js
@@ -9,17 +9,17 @@ $(function()
   var menu         = chrome.extension.getBackgroundPage().WebDeveloper.Storage.getItem("menu");
   var notification = $("#notification");
 
-  $("#cookies-toolbar > a").append(WebDeveloper.Locales.getString("cookies"));
-  $("#css-toolbar > a").append(WebDeveloper.Locales.getString("css"));
-  $("#disable-toolbar > a").append(WebDeveloper.Locales.getString("disable"));
-  $("#forms-toolbar > a").append(WebDeveloper.Locales.getString("forms"));
-  $("#images-toolbar > a").append(WebDeveloper.Locales.getString("images"));
-  $("#information-toolbar > a").append(WebDeveloper.Locales.getString("information"));
-  $("#miscellaneous-toolbar > a").append(WebDeveloper.Locales.getString("miscellaneous"));
-  $("#options-toolbar > a").append(WebDeveloper.Locales.getString("options"));
-  $("#outline-toolbar > a").append(WebDeveloper.Locales.getString("outline"));
-  $("#resize-toolbar > a").append(WebDeveloper.Locales.getString("resize"));
-  $("#tools-toolbar > a").append(WebDeveloper.Locales.getString("tools"));
+  $("#cookies-toolbar > a").attr("title", WebDeveloper.Locales.getString("cookies"));
+  $("#css-toolbar > a").attr("title", WebDeveloper.Locales.getString("css"));
+  $("#disable-toolbar > a").attr("title", WebDeveloper.Locales.getString("disable"));
+  $("#forms-toolbar > a").attr("title", WebDeveloper.Locales.getString("forms"));
+  $("#images-toolbar > a").attr("title", WebDeveloper.Locales.getString("images"));
+  $("#information-toolbar > a").attr("title", WebDeveloper.Locales.getString("information"));
+  $("#miscellaneous-toolbar > a").attr("title", WebDeveloper.Locales.getString("miscellaneous"));
+  $("#options-toolbar > a").attr("title", WebDeveloper.Locales.getString("options"));
+  $("#outline-toolbar > a").attr("title", WebDeveloper.Locales.getString("outline"));
+  $("#resize-toolbar > a").attr("title", WebDeveloper.Locales.getString("resize"));
+  $("#tools-toolbar > a").attr("title", WebDeveloper.Locales.getString("tools"));
 
   // If the menu is not set
   if(!menu)


### PR DESCRIPTION
Since it's impossible to overcome 800px width for an extension in Chrome, it's possible to move tabs captions to the link title attribute. It partly solves the whole problem as can be seen on the figures. The lists under the tab should also be fixed.

Original:
![err](https://cloud.githubusercontent.com/assets/8587695/5853775/9174e372-a22f-11e4-8216-0989935f2a2e.png)
Fixed:
![result](https://cloud.githubusercontent.com/assets/8587695/5853776/917c0eea-a22f-11e4-926d-4764891887fc.png)
