### PR TITLE
Fix disable images option for generated content

### DIFF
--- a/source/common/style-sheets/features/images/hide-background-images.css
+++ b/source/common/style-sheets/features/images/hide-background-images.css
@@ -1,1 +1,1 @@
-* { background-image: none !important; }
+*, *:after, *:before { background-image: none !important; }

--- a/source/common/style-sheets/features/images/hide-images.css
+++ b/source/common/style-sheets/features/images/hide-images.css
@@ -1,2 +1,2 @@
-* { background-image: none !important; }
+*, *:after, *:before { background-image: none !important; }
 img { display: none !important; }


### PR DESCRIPTION
Disabling images option doesn't work for background-images placed in generated content.