### PR TITLE
Update overlay.dtd for locale ja-JP

### DIFF
--- a/source/firefox/locales/ja-JP/overlay/overlay.dtd
+++ b/source/firefox/locales/ja-JP/overlay/overlay.dtd
@@ -325,7 +325,7 @@
 <!ENTITY webdeveloper.outline.deprecated.elements.key "D">
 <!ENTITY webdeveloper.outline.external.links.label "外部リンクを枠で囲う">
 <!ENTITY webdeveloper.outline.external.links.key "E">
-<!ENTITY webdeveloper.outline.floated.elements.label "再前面のレイヤー要素を枠で囲う">
+<!ENTITY webdeveloper.outline.floated.elements.label "最前面のレイヤー要素を枠で囲う">
 <!ENTITY webdeveloper.outline.floated.elements.key "F">
 <!ENTITY webdeveloper.outline.frames.label "フレームを枠で囲う">
 <!ENTITY webdeveloper.outline.frames.key "u">


### PR DESCRIPTION
I guess '再前面' is a typo.
Both '再' and '最' are called 'SAI' in Japanese.
'最前面' correctly means 'foreground'.
