### PR TITLE
Remove Dribbble

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,6 @@ For announcements about the Web Developer extension including news about beta re
 
 * Blog: [http://chrispederick.com/blog/](http://chrispederick.com/blog/)
 * Twitter: [http://twitter.com/chrispederick/](http://twitter.com/chrispederick/)
-* Dribbble: [http://dribbble.com/chrispederick/projects/9762-Web-Developer](http://dribbble.com/chrispederick/projects/9762-Web-Developer)
 
 Help
 ----


### PR DESCRIPTION
Remove the broken link to Dribbble, where the most recent shot in @ChrisPederick’s account is [from 2013](https://dribbble.com/chrispederick).