### PR TITLE
Limiting security scope from all URLs to activeTab

### DIFF
--- a/configuration/chrome/manifest.json
+++ b/configuration/chrome/manifest.json
@@ -1,4 +1,4 @@
 {"remove-top": "",
   "browser_action": { "default_icon": { "16": "/common/images/logos/16.png", "24":  "/common/images/logos/24.png", "32":  "/common/images/logos/32.png", "48":  "/common/images/logos/48.png", "64":  "/common/images/logos/64.png", "128": "/common/images/logos/128.png", "256": "/common/images/logos/256.png", "512": "/common/images/logos/512.png" }, "default_popup": "/overlay/overlay.html", "default_title": "__MSG_extensionName__" },
-  "permissions": ["browsingData", "clipboardWrite", "contentSettings", "cookies", "history", "storage", "tabs", "<all_urls>"],
+  "permissions": ["browsingData", "clipboardWrite", "contentSettings", "cookies", "history", "storage", "tabs", "activeTab"],
 "remove-bottom": ""}


### PR DESCRIPTION
Would it be possible to use "activeTab" instead of "<all_urls>"? This would improve the security of the extension by reducing the scope of access while also getting rid of the warning how it needs to read all data on all sites. This changes the experience, however, because users will need to invoke the extension icon when wanting to use it. The extension will lose its access if the user navigates away or closes the tab. Just something to consider.

https://developer.chrome.com/docs/extensions/mv3/manifest/activeTab/